### PR TITLE
Add a vm config with vagrant kvm and libvirt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Vagrant stuff
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,82 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "generic/ubuntu2204"
+
+  config.vm.provider "libvirt" do |vm|
+    vm.memory = 8192
+    vm.cpus = 2
+  end
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Disable the default share of the current code directory. Doing this
+  # provides improved isolation between the vagrant box and your host
+  # by making sure your Vagrantfile isn't accessible to the vagrant box.
+  # If you use this you may want to enable additional shared subfolders as
+  # shown above.
+  # config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/docs/vm_install.md
+++ b/docs/vm_install.md
@@ -1,0 +1,153 @@
+# Summary
+
+By following this comprehensive guide, you will have a fully functioning setup of Vagrant with Libvirt/KVM. This setup includes all necessary installations, configurations, and troubleshooting steps to ensure a smooth operation. If you encounter further issues, please provide the specific error messages or logs for further assistance.
+
+### Step 1: Install KVM and Libvirt
+
+1. **Update Package List and Install Required Packages**:
+
+   ```bash
+   sudo apt-get update
+   sudo apt-get install -y qemu-kvm libvirt-daemon-system libvirt-clients bridge-utils libvirt-dev build-essential
+   ```
+
+2. **Enable and Start the Libvirt Daemon**:
+
+   ```bash
+   sudo systemctl enable libvirtd
+   sudo systemctl start libvirtd
+   ```
+
+3. **Add Your User to the Libvirt Group**:
+
+   ```bash
+   sudo usermod -aG libvirt $(whoami)
+   ```
+
+4. **Restart Your Session**:
+   - Log out and log back in, or reboot your system to apply the group change.
+
+### Step 2: Install Vagrant
+
+1. **Download and Install Vagrant**:
+
+   ```bash
+   curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+   sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+   sudo apt-get update && sudo apt-get install vagrant
+   ```
+
+2. **Verify the Installation**:
+
+   ```bash
+   vagrant --version
+   ```
+
+### Step 3: Install the Vagrant Libvirt Plugin
+
+1. **Install the Vagrant Libvirt Plugin**:
+
+   ```bash
+   vagrant plugin install vagrant-libvirt
+   ```
+
+### Step 4: Create a Vagrant Project
+
+1. **Initialize a New Vagrant Project**:
+
+   ```bash
+   mkdir my-vagrant-project
+   cd my-vagrant-project
+   vagrant init generic/ubuntu2204
+   ```
+
+2. **Configure the Vagrantfile**:
+   - Edit the `Vagrantfile` to use the Libvirt provider:
+
+     ```ruby
+     Vagrant.configure("2") do |config|
+       config.vm.box = "generic/ubuntu2204"
+
+       config.vm.provider :libvirt do |libvirt|
+         libvirt.memory = 8196
+         libvirt.cpus = 2
+       end
+     end
+     ```
+
+### Step 5: Start the Vagrant Environment
+
+1. **Bring Up the Vagrant Environment**:
+
+   ```bash
+   vagrant up --provider=libvirt
+   ```
+
+2. **Interact with the VM**:
+
+   ```bash
+   vagrant ssh
+   ```
+
+3. **Manage the VM**:
+   - You can halt, destroy, and manage the VM using standard Vagrant commands:
+
+     ```bash
+     vagrant halt     # Stop the VM
+     vagrant destroy  # Destroy the VM
+     ```
+
+### Troubleshooting Steps
+
+If you encounter any issues, here are additional troubleshooting steps:
+
+1. **Check Libvirt Service Status**:
+
+   ```bash
+   sudo systemctl status libvirtd
+   ```
+
+2. **Ensure Proper Permissions**:
+   - Check permissions on the libvirt socket:
+
+     ```bash
+     ls -l /var/run/libvirt/libvirt-sock
+     ```
+
+   - The output should be:
+     ```
+     srw-rw---- 1 root libvirt 0 Jun 25 12:34 /var/run/libvirt/libvirt-sock
+     ```
+
+   - Adjust permissions if necessary:
+
+     ```bash
+     sudo chmod 660 /var/run/libvirt/libvirt-sock
+     sudo chown root:libvirt /var/run/libvirt/libvirt-sock
+     ```
+
+3. **Test Connection to Libvirt**:
+
+   ```bash
+   virsh -c qemu:///system list
+   ```
+
+   - If it fails, try with `sudo`:
+
+     ```bash
+     sudo virsh -c qemu:///system list
+     ```
+
+4. **Check Logs for More Details**:
+
+   ```bash
+   sudo journalctl -xeu libvirtd
+   ```
+
+5. **Reinstall Vagrant Libvirt Plugin (if necessary)**:
+
+   ```bash
+   vagrant plugin uninstall vagrant-libvirt
+   vagrant plugin install vagrant-libvirt
+   ```
+


### PR DESCRIPTION
Adds Vagrant support for KVM and Libvirt to QuickCluster.

**Vagrant** Configuration:

- Added a Vagrantfile configured for KVM and Libvirt.

- Included necessary plugins and settings to support virtualization.

**Documentation** Updates:

- Updated README.md with setup instructions for KVM and Libvirt.

- Provided detailed steps for installing necessary dependencies and configuring the environment.

**Testing** and Compatibility:

- Verified functionality only on kubuntu and debian.