### PR TITLE
Provision kubernetes and kind

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,4 +26,19 @@ Vagrant.configure("2") do |config|
     # https://developer.hashicorp.com/vagrant/docs/provisioning/docker
   end
 
+  # Provision kubectl
+  config.vm.provision "shell", inline: <<-SHELL
+    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+    sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+    kubectl version --client
+  SHELL
+
+    # Provision Kind
+  config.vm.provision "shell", inline: <<-SHELL
+    curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.11.1/kind-linux-amd64
+    chmod +x ./kind
+    sudo mv ./kind /usr/local/bin/kind
+    kind --version
+  SHELL
+
 end


### PR DESCRIPTION
### Add Provisioning for kubectl and Kind in Vagrant Setup

#### Description

This PR enhances our Vagrant configuration by adding scripts to provision `kubectl` and `kind`

#### Changes made:

1. **Provision `kubectl`:**
   - Downloads the latest stable version of `kubectl` via curl.
   - Installs `kubectl` in `/usr/local/bin/` with the necessary permissions.
   - Verifies the installation by checking the client version.

2. **Provision `Kind`:**
   - Downloads the `kind` binary.
   - Makes the binary executable.
   - Moves `kind` to `/usr/local/bin/`.
   - Verifies the installation by checking the version.

#### How to test it?

1. Pull the latest changes from the `feature/kubernetes` branch.
2. Run `vagrant up` to start and provision the Vagrant environment.
3. Check the installation of `kubectl` by running:
   ```bash
   kubectl version --client
   ```
4. Check the installation of `kind` by running:
   ```bash
   kind --version
   ```
